### PR TITLE
Replace git.io with expanded URLs

### DIFF
--- a/vars/groovydoc/stylesheet.css
+++ b/vars/groovydoc/stylesheet.css
@@ -1,6 +1,6 @@
 @charset "UTF-8";
 
-/*! normalize.css v2.1.0 | MIT License | git.io/normalize */
+/*! normalize.css v2.1.0 | MIT License | https://github.com/anishathalye/?normalize */
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
     display: block
 }


### PR DESCRIPTION
https://github.blog/changelog/2022-04-25-git-io-deprecation/ announces end of life for the git.io service

jenkins-infra/update-center2#588

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
